### PR TITLE
Fix bodyMarginBottomHeight-related bugs in DebugBar

### DIFF
--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -396,7 +396,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
 
         options: {
             bodyMarginBottom: true,
-            bodyMarginBottomHeight: parseInt($('body').css('margin-bottom'))
+            bodyMarginBottomHeight: 0
         },
 
         initialize: function() {
@@ -406,6 +406,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
             this.firstTabName = null;
             this.activePanelName = null;
             this.datesetTitleFormater = new DatasetTitleFormater(this);
+            this.options.bodyMarginBottomHeight = parseInt($('body').css('margin-bottom'));
             this.registerResizeHandler();
         },
 
@@ -831,7 +832,7 @@ if (typeof(PhpDebugBar) == 'undefined') {
                     return $('body').css('margin-bottom', this.options.bodyMarginBottomHeight || '');
                 }
                 
-                var offset = parseInt(this.$el.height()) + this.options.bodyMarginBottomHeight;
+                var offset = parseInt(this.$el.height()) + (this.options.bodyMarginBottomHeight || 0);
                 $('body').css('margin-bottom', offset);
             }
         },


### PR DESCRIPTION
This fixes two problems:

1.  In recomputeBottomOffset, if bodyMarginBottomHeight is NaN, we need
    to change that to a 0 before adding so we don’t end up setting
    the offset variable to NaN.

2.  We now initialize bodyMarginBottomHeight in the initialize function.
    This fixes a bug where bodyMarginBottomHeight gets set to NaN if the
    debugbar.js is included in the page header and not the page body
    (i.e. before the body element has been loaded).